### PR TITLE
Ignore Unknown property in API-server and KafkaConsumer

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
@@ -25,6 +26,7 @@ import org.slf4j.LoggerFactory
 val objectMapper: ObjectMapper = ObjectMapper()
     .registerModule(JavaTimeModule())
     .registerKotlinModule()
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
 
 val log: Logger = LoggerFactory.getLogger("no.nav.syfo.BootstrapKt")

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEngine.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEngine.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.application
 
 import com.auth0.jwk.JwkProviderBuilder
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
@@ -35,6 +36,7 @@ fun createApplicationEngine(
             jackson {
                 registerKotlinModule()
                 registerModule(JavaTimeModule())
+                configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             }
         }

--- a/src/test/kotlin/no/nav/syfo/api/GetStatusSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/GetStatusSpek.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.api
 
 import com.auth0.jwk.JwkProviderBuilder
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -97,6 +98,7 @@ class GetStatusSpek : Spek({
             jackson {
                 registerKotlinModule()
                 registerModule(JavaTimeModule())
+                configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             }
         }

--- a/src/test/kotlin/no/nav/syfo/api/PostStatusSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/PostStatusSpek.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.api
 
 import com.auth0.jwk.JwkProviderBuilder
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -99,6 +100,7 @@ class PostStatusSpek : Spek({
             jackson {
                 registerKotlinModule()
                 registerModule(JavaTimeModule())
+                configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             }
         }

--- a/src/test/kotlin/no/nav/syfo/api/testutils/MockServer.kt
+++ b/src/test/kotlin/no/nav/syfo/api/testutils/MockServer.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.api.testutils
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
@@ -22,6 +23,7 @@ fun mockSyfotilgangskontrollServer(port: Int, fnr: SykmeldtFnr): ApplicationEngi
             jackson {
                 registerKotlinModule()
                 registerModule(JavaTimeModule())
+                configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             }
         }


### PR DESCRIPTION
Ingore unknown fields when deserialization of object both in kafka and in API to provide fault tolerance in case of changes.