### PR TITLE
Update Tilgangskontroll for person

### DIFF
--- a/src/test/kotlin/no/nav/syfo/api/testutils/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/api/testutils/VeilederTilgangskontrollMock.kt
@@ -10,6 +10,8 @@ import no.nav.syfo.api.testutils.UserConstants.SYKMELDT_FNR
 import no.nav.syfo.api.testutils.UserConstants.SYKMELDT_FNR_IKKE_TILGANG
 import no.nav.syfo.application.installContentNegotiation
 import no.nav.syfo.client.tilgangskontroll.TilgangDTO
+import no.nav.syfo.client.tilgangskontroll.TilgangskontrollConsumer.Companion.TILGANGSKONTROLL_PERSON_PATH
+import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 
 class VeilederTilgangskontrollMock {
     private val port = getRandomPort()
@@ -41,11 +43,13 @@ class VeilederTilgangskontrollMock {
         ) {
             installContentNegotiation()
             routing {
-                get("/syfo-tilgangskontroll/api/tilgang/navident/bruker/${SYKMELDT_FNR.value}") {
-                    call.respond(tilgangTrue)
-                }
-                get("/syfo-tilgangskontroll/api/tilgang/navident/bruker/${SYKMELDT_FNR_IKKE_TILGANG.value}") {
-                    call.respond(HttpStatusCode.Forbidden, tilgangFalse)
+                get(TILGANGSKONTROLL_PERSON_PATH) {
+                    if (call.request.headers[NAV_PERSONIDENT_HEADER] == SYKMELDT_FNR.value) {
+                        call.respond(tilgangTrue)
+                    }
+                    if (call.request.headers[NAV_PERSONIDENT_HEADER] == SYKMELDT_FNR_IKKE_TILGANG.value) {
+                        call.respond(HttpStatusCode.Forbidden, tilgangFalse)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Update to newest person-tilgangskontroll in Syfo-tilgangskontroll. This endpoint requires PersonIdent as a header instead of as a parameter in the URL.