### PR TITLE
Create aiven-topic in dev-gcp

### DIFF
--- a/.github/workflows/kafka-stoppautomatikk.yaml
+++ b/.github/workflows/kafka-stoppautomatikk.yaml
@@ -1,0 +1,24 @@
+name: kafka
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/kafka-stoppautomatikk.yaml'
+      - '.nais/kafka/stoppautomatikk.yaml'
+      - '.nais/kafka/dev.json'
+      - '.nais/kafka/prod.json'
+
+jobs:
+  deploy-kafka-stoppautomatikk-dev:
+    name: Deploy Kafka topic stoppautomatikk to NAIS dev-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/kafka/stoppautomatikk.yaml
+          VARS: .nais/kafka/dev.json

--- a/.nais/kafka/dev.json
+++ b/.nais/kafka/dev.json
@@ -1,0 +1,3 @@
+{
+  "kafkaPool": "nav-dev"
+}

--- a/.nais/kafka/prod.json
+++ b/.nais/kafka/prod.json
@@ -1,0 +1,3 @@
+{
+  "kafkaPool": "nav-prod"
+}

--- a/.nais/kafka/stoppautomatikk.yaml
+++ b/.nais/kafka/stoppautomatikk.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  annotations:
+    dcat.data.nav.no/title: "Stoppautomatikk"
+    dcat.data.nav.no/description: >-
+      Topic inneholder informasjon om sykmeldte personer der stopp i sykepenger har blitt anmodet.
+  name: apen-isyfo-stoppautomatikk
+  namespace: teamsykefravr
+  labels:
+    team: teamsykefravr
+spec:
+  pool: {{ kafkaPool }}
+  config:
+    cleanupPolicy: delete
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: -1  # -1 means unlimited
+  acl:
+    - team: teamsykefravr
+      application: ispengestopp
+      access: readwrite
+    - team: risk
+      application: helserisk-isyfo
+      access: read

--- a/.nais/kafka/stoppautomatikk.yaml
+++ b/.nais/kafka/stoppautomatikk.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     dcat.data.nav.no/title: "Stoppautomatikk"
     dcat.data.nav.no/description: >-
-      Topic inneholder informasjon om sykmeldte personer der stopp i sykepenger har blitt anmodet.
+      Topic inneholder informasjon om sykmeldte personer der veileder ønsker stopp i automatisk behandling av sykepengesøknader.
   name: apen-isyfo-stoppautomatikk
   namespace: teamsykefravr
   labels:

--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -56,6 +56,8 @@ spec:
       claims:
         extra:
           - "NAVident"
+  kafka:
+    pool: nav-dev
   gcp:
     sqlInstances:
       - type: POSTGRES_14

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -56,6 +56,8 @@ spec:
       claims:
         extra:
           - "NAVident"
+  kafka:
+    pool: nav-prod
   gcp:
     sqlInstances:
       - type: POSTGRES_14


### PR DESCRIPTION
Oppretter topic som skal ta over for onprem-topic. Opprettes i dev-gcp i første omgang.