### PR TITLE
IS: Adding db tier

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -60,6 +60,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-f1-micro
         databases:
           - name: ispengestopp-db
         diskAutoresize: true

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -60,6 +60,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-f1-micro
         databases:
           - name: ispengestopp-db
         diskAutoresize: true


### PR DESCRIPTION
Legger til db tier.
`db-f1-micro` i prod ettersom denne har lite trafikk. Var det du foreslo for `syfobehandlendeenhet` også @geir-waagboe ? 😊