### PR TITLE
IS-3112: Gjør virksomhetNr og enhetNr nullable i database og modell

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/PStatusEndring.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/PStatusEndring.kt
@@ -10,9 +10,9 @@ data class PStatusEndring(
     val personIdent: PersonIdent,
     val veilederIdent: VeilederIdent,
     val status: Status,
-    val virksomhetNr: VirksomhetNr,
+    val virksomhetNr: VirksomhetNr?,
     val opprettet: OffsetDateTime,
-    val enhetNr: EnhetNr
+    val enhetNr: EnhetNr?
 )
 
 fun PStatusEndring.toStatusEndring(arsaker: List<Arsak>): StatusEndring =

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/PengestoppRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/PengestoppRepository.kt
@@ -16,8 +16,8 @@ class PengestoppRepository(private val database: DatabaseInterface) : IPengestop
             it.setString(2, statusEndring.sykmeldtFnr.value)
             it.setString(3, statusEndring.veilederIdent.value)
             it.setString(4, statusEndring.status.name)
-            it.setString(5, statusEndring.virksomhetNr.value)
-            it.setString(6, statusEndring.enhetNr.value)
+            it.setObject(5, statusEndring.virksomhetNr?.value)
+            it.setObject(6, statusEndring.enhetNr?.value)
             it.setObject(7, Timestamp.from(statusEndring.opprettet.toInstant()))
             it.executeQuery().toList { getInt("id") }.single()
         }
@@ -145,7 +145,7 @@ internal fun ResultSet.statusEndring(): PStatusEndring =
         veilederIdent = VeilederIdent(getString("veileder_ident")),
         personIdent = PersonIdent(getString("sykmeldt_fnr")),
         status = Status.valueOf(getString("status")),
-        virksomhetNr = VirksomhetNr(getString("virksomhet_nr")),
+        virksomhetNr = getString("virksomhet_nr")?.let { VirksomhetNr(it) },
         opprettet = getTimestamp("opprettet").toInstant().atOffset(ZoneOffset.UTC),
-        enhetNr = EnhetNr(getString("enhet_nr"))
+        enhetNr = getString("enhet_nr")?.let { EnhetNr(it) }
     )

--- a/src/main/kotlin/no/nav/syfo/pengestopp/Domain.kt
+++ b/src/main/kotlin/no/nav/syfo/pengestopp/Domain.kt
@@ -26,9 +26,9 @@ data class StatusEndring(
     val sykmeldtFnr: PersonIdent,
     val status: Status,
     val arsakList: List<Arsak>,
-    val virksomhetNr: VirksomhetNr,
+    val virksomhetNr: VirksomhetNr?,
     val opprettet: OffsetDateTime,
-    val enhetNr: EnhetNr // For å holde oversikt over hvem som bruker tjenesten
+    val enhetNr: EnhetNr? // For å holde oversikt over hvem som bruker tjenesten
 )
 
 enum class SykepengestoppArsak {

--- a/src/main/resources/db/migration/V4_6__alter_columns_nullable.sql
+++ b/src/main/resources/db/migration/V4_6__alter_columns_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE status_endring ALTER COLUMN enhet_nr DROP NOT NULL;
+ALTER TABLE status_endring ALTER COLUMN virksomhet_nr DROP NOT NULL;

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/PengestoppRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/PengestoppRepositorySpek.kt
@@ -1,0 +1,46 @@
+package no.nav.syfo.infrastructure.database
+
+import no.nav.syfo.pengestopp.*
+import no.nav.syfo.testutils.TestDB
+import no.nav.syfo.testutils.UserConstants
+import no.nav.syfo.testutils.dropData
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class PengestoppRepositorySpek : Spek({
+    describe(PengestoppRepository::class.java.simpleName) {
+
+        val database = TestDB()
+        val repository = PengestoppRepository(database = database)
+
+        afterEachTest {
+            database.connection.use { it.dropData() }
+        }
+
+        it("creates StatusEndring without virksomhetNr and enhetNr") {
+            val statusEndring = StatusEndring(
+                uuid = UUID.randomUUID().toString(),
+                veilederIdent = VeilederIdent("Z999999"),
+                sykmeldtFnr = UserConstants.SYKMELDT_PERSONIDENT,
+                status = Status.STOPP_AUTOMATIKK,
+                arsakList = listOf(Arsak(type = SykepengestoppArsak.MANGLENDE_MEDVIRKING)),
+                virksomhetNr = null,
+                opprettet = OffsetDateTime.now(),
+                enhetNr = null,
+            )
+
+            repository.createStatusEndring(statusEndring)
+
+            val storedStatusendring = repository.getStatusEndringer(UserConstants.SYKMELDT_PERSONIDENT).first()
+
+            storedStatusendring.uuid shouldBeEqualTo statusEndring.uuid
+            storedStatusendring.sykmeldtFnr shouldBeEqualTo UserConstants.SYKMELDT_PERSONIDENT
+            storedStatusendring.virksomhetNr.shouldBeNull()
+            storedStatusendring.enhetNr.shouldBeNull()
+        }
+    }
+})


### PR DESCRIPTION
Speil bryr seg ikke om disse feltene og vi ønsker heller ikke å sette de når vi skal trykke på stoppknappen automatisk på bakgrunn av avslag/stans 8-4/8-8/aktivitetskravet. Har ikke gjort noen tilpasninger av veileder-APIet her (eller testene der) siden det uansett kan fjernes når vi gjør all bruk av stoppknapp automatisk. 
