### PR TITLE
IS-3111: Consume arbeidsuforhet vurderinger

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,9 +179,7 @@ tasks {
     }
 
     test {
-        useJUnitPlatform {
-            includeEngines("spek2")
-        }
+        useJUnitPlatform()
         testLogging.showStandardStreams = true
     }
 }

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -23,6 +23,7 @@ import no.nav.syfo.infrastructure.kafka.identhendelse.IdenthendelseConsumerServi
 import no.nav.syfo.infrastructure.kafka.identhendelse.launchKafkaTaskIdenthendelse
 import no.nav.syfo.infrastructure.database.PengestoppRepository
 import no.nav.syfo.infrastructure.kafka.StatusEndringProducer
+import no.nav.syfo.infrastructure.kafka.arbeidsuforhet.launchKafkaTaskArbeidsuforhet
 import no.nav.syfo.infrastructure.kafka.createPersonFlagget84AivenConsumer
 import no.nav.syfo.infrastructure.kafka.launchKafkaTask
 import no.nav.syfo.infrastructure.kafka.manglendemedvirkning.launchKafkaTaskManglendeMedvirkning
@@ -128,6 +129,11 @@ fun main() {
                     kafkaIdenthendelseConsumerService = kafkaIdenthendelseConsumerService,
                 )
                 launchKafkaTaskManglendeMedvirkning(
+                    applicationState = applicationState,
+                    environment = environment,
+                    pengestoppService = pengestoppService,
+                )
+                launchKafkaTaskArbeidsuforhet(
                     applicationState = applicationState,
                     environment = environment,
                     pengestoppService = pengestoppService,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/arbeidsuforhet/ArbeidsuforhetVurderingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/arbeidsuforhet/ArbeidsuforhetVurderingConsumer.kt
@@ -1,0 +1,46 @@
+package no.nav.syfo.infrastructure.kafka.arbeidsuforhet
+
+import no.nav.syfo.application.PengestoppService
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.pengestopp.*
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.*
+
+class ArbeidsuforhetVurderingConsumer(
+    private val pengestoppService: PengestoppService,
+    private val kafkaConsumer: KafkaConsumer<String, ArbeidsuforhetVurderingRecord>
+) {
+    fun pollAndProcessRecords() {
+        val records = kafkaConsumer.poll(Duration.ofSeconds(POLL_DURATION_SECONDS))
+        if (records.count() > 0) {
+            val avslagVurderinger = records.mapNotNull { it.value() }.filter { it.type == VurderingType.AVSLAG }
+            if (avslagVurderinger.isNotEmpty()) {
+                val statusEndringer = avslagVurderinger.map {
+                    StatusEndring(
+                        uuid = UUID.randomUUID().toString(),
+                        veilederIdent = VeilederIdent(it.veilederident),
+                        sykmeldtFnr = PersonIdent(it.personident),
+                        status = Status.STOPP_AUTOMATIKK,
+                        arsakList = listOf(Arsak(SykepengestoppArsak.MEDISINSK_VILKAR)),
+                        virksomhetNr = null,
+                        opprettet = OffsetDateTime.now(ZoneOffset.UTC),
+                        enhetNr = null,
+                    )
+                }
+
+                pengestoppService.createStatusendringer(statusEndringer)
+                log.info("ArbeidsuforhetVurderingConsumer created ${statusEndringer.size} statusendringer")
+            }
+        }
+        kafkaConsumer.commitSync()
+    }
+
+    companion object {
+        private const val POLL_DURATION_SECONDS = 10L
+        private val log = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/arbeidsuforhet/ArbeidsuforhetVurderingRecord.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/arbeidsuforhet/ArbeidsuforhetVurderingRecord.kt
@@ -1,0 +1,26 @@
+package no.nav.syfo.infrastructure.kafka.arbeidsuforhet
+
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.*
+
+data class ArbeidsuforhetVurderingRecord(
+    val uuid: UUID,
+    val createdAt: OffsetDateTime,
+    val personident: String,
+    val veilederident: String,
+    val type: VurderingType,
+    val arsak: VurderingArsak?,
+    val begrunnelse: String,
+    val gjelderFom: LocalDate?,
+    val isFinal: Boolean,
+)
+
+enum class VurderingType(val isFinal: Boolean) {
+    FORHANDSVARSEL(false), OPPFYLT(true), AVSLAG(true), IKKE_AKTUELL(true);
+}
+
+enum class VurderingArsak {
+    FRISKMELDT,
+    FRISKMELDING_TIL_ARBEIDSFORMIDLING,
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/arbeidsuforhet/KafkaArbeidsuforhetTask.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/arbeidsuforhet/KafkaArbeidsuforhetTask.kt
@@ -1,0 +1,58 @@
+package no.nav.syfo.infrastructure.kafka.arbeidsuforhet
+
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.Environment
+import no.nav.syfo.application.PengestoppService
+import no.nav.syfo.application.launchBackgroundTask
+import no.nav.syfo.infrastructure.kafka.KafkaEnvironment
+import no.nav.syfo.infrastructure.kafka.commonKafkaAivenConsumerConfig
+import no.nav.syfo.objectMapper
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.Deserializer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.*
+
+const val TOPIC = "teamsykefravr.arbeidsuforhet-vurdering"
+val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
+
+fun launchKafkaTaskArbeidsuforhet(
+    applicationState: ApplicationState,
+    environment: Environment,
+    pengestoppService: PengestoppService,
+) {
+    launchBackgroundTask(
+        applicationState = applicationState
+    ) {
+        log.info("Setting up kafka consumer for ${ArbeidsuforhetVurderingRecord::class.java.simpleName}")
+
+        val kafkaConsumer = KafkaConsumer<String, ArbeidsuforhetVurderingRecord>(
+            kafkaConsumerConfig(kafkaEnvironment = environment.kafka)
+        )
+        val arbeidsuforhetVurderingConsumer = ArbeidsuforhetVurderingConsumer(
+            pengestoppService = pengestoppService,
+            kafkaConsumer = kafkaConsumer,
+        )
+
+        while (applicationState.ready) {
+            if (kafkaConsumer.subscription().isEmpty()) {
+                kafkaConsumer.subscribe(listOf(TOPIC))
+            }
+            arbeidsuforhetVurderingConsumer.pollAndProcessRecords()
+        }
+    }
+}
+
+private fun kafkaConsumerConfig(
+    kafkaEnvironment: KafkaEnvironment,
+): Properties = Properties().apply {
+    putAll(commonKafkaAivenConsumerConfig(kafkaEnvironment))
+    this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = ArbeidsuforhetVurderingRecordDeserializer::class.java.canonicalName
+    this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "latest"
+}
+
+class ArbeidsuforhetVurderingRecordDeserializer : Deserializer<ArbeidsuforhetVurderingRecord> {
+    override fun deserialize(topic: String, data: ByteArray): ArbeidsuforhetVurderingRecord =
+        objectMapper.readValue(data, ArbeidsuforhetVurderingRecord::class.java)
+}

--- a/src/test/kotlin/no/nav/syfo/infrastructure/kafka/arbeidsuforhet/ArbeidsuforhetVurderingConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/kafka/arbeidsuforhet/ArbeidsuforhetVurderingConsumerTest.kt
@@ -1,0 +1,101 @@
+package no.nav.syfo.infrastructure.kafka.arbeidsuforhet
+
+import io.mockk.*
+import no.nav.syfo.application.PengestoppService
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.infrastructure.database.PengestoppRepository
+import no.nav.syfo.infrastructure.kafka.StatusEndringProducer
+import no.nav.syfo.pengestopp.Status
+import no.nav.syfo.pengestopp.StatusEndring
+import no.nav.syfo.pengestopp.SykepengestoppArsak
+import no.nav.syfo.testutils.TestDB
+import no.nav.syfo.testutils.dropData
+import no.nav.syfo.testutils.generator.generateArbeidsuforhetVurdering
+import no.nav.syfo.testutils.mockRecords
+import no.nav.syfo.testutils.testEnvironment
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.Future
+import kotlin.test.assertEquals
+
+class ArbeidsuforhetVurderingConsumerTest {
+
+    val database = TestDB()
+    val env = testEnvironment()
+
+    val kafkaProducer = mockk<KafkaProducer<String, StatusEndring>>()
+    val kafkaConsumer = mockk<KafkaConsumer<String, ArbeidsuforhetVurderingRecord>>()
+
+    val repository = PengestoppRepository(database = database)
+    val statusEndringProducer = StatusEndringProducer(
+        environment = env,
+        kafkaProducer = kafkaProducer
+    )
+    val pengestoppService = PengestoppService(pengestoppRepository = repository, statusEndringProducer = statusEndringProducer)
+
+    val arbeidsuforhetVurderingConsumer = ArbeidsuforhetVurderingConsumer(
+        pengestoppService = pengestoppService,
+        kafkaConsumer = kafkaConsumer
+    )
+
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+        every { kafkaConsumer.commitSync() } returns Unit
+        every { kafkaProducer.send(any()) } returns mockk<Future<RecordMetadata>>(relaxed = true)
+        database.dropData()
+    }
+
+    @Test
+    fun `creates statusendring and publish to kafka when arbeidsuforhetvurdering is AVSLAG`() {
+        val vurdering = generateArbeidsuforhetVurdering(VurderingType.AVSLAG)
+        val records = mockRecords(listOf(vurdering))
+        every { kafkaConsumer.poll(any<Duration>()) } returns records
+
+        arbeidsuforhetVurderingConsumer.pollAndProcessRecords()
+
+        val statusEndring = repository.getStatusEndringer(personIdent = PersonIdent(vurdering.personident)).firstOrNull()
+        assertEquals(statusEndring?.arsakList?.get(0)?.type, SykepengestoppArsak.MEDISINSK_VILKAR)
+        assertEquals(statusEndring?.sykmeldtFnr?.value, vurdering.personident)
+        assertEquals(statusEndring?.status, Status.STOPP_AUTOMATIKK)
+        assertEquals(statusEndring?.veilederIdent?.value, vurdering.veilederident)
+
+        verify(exactly = 1) { kafkaProducer.send(any()) }
+        verify(exactly = 1) { kafkaConsumer.commitSync() }
+    }
+
+    @Test
+    fun `creates several statusendinger when multiple arbeidsuforhetvurderinger are AVSLAG`() {
+        val vurdering1 = generateArbeidsuforhetVurdering(VurderingType.AVSLAG)
+        val vurdering2 = generateArbeidsuforhetVurdering(VurderingType.AVSLAG)
+        val records = mockRecords(listOf(vurdering1, vurdering2))
+        every { kafkaConsumer.poll(any<Duration>()) } returns records
+
+        arbeidsuforhetVurderingConsumer.pollAndProcessRecords()
+
+        val statusEndringer = repository.getStatusEndringer(personIdent = PersonIdent(vurdering1.personident))
+        assertEquals(statusEndringer.size, 2)
+
+        verify(exactly = 2) { kafkaProducer.send(any()) }
+        verify(exactly = 1) { kafkaConsumer.commitSync() }
+    }
+
+    @Test
+    fun `does not create statusendring nor publish to kafka when arbeidsuforhetvurdering is not AVSLAG`() {
+        val vurdering = generateArbeidsuforhetVurdering(VurderingType.OPPFYLT)
+        val records = mockRecords(listOf(vurdering))
+        every { kafkaConsumer.poll(any<Duration>()) } returns records
+
+        arbeidsuforhetVurderingConsumer.pollAndProcessRecords()
+
+        val statusEndring = repository.getStatusEndringer(personIdent = PersonIdent(vurdering.personident)).firstOrNull()
+        assertEquals(statusEndring, null)
+
+        verify(exactly = 0) { kafkaProducer.send(any()) }
+        verify(exactly = 1) { kafkaConsumer.commitSync() }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/kafka/manglendemedvirkning/ManglendeMedvirkningVurderingConsumerSpek.kt
@@ -5,20 +5,14 @@ import no.nav.syfo.application.PengestoppService
 import no.nav.syfo.infrastructure.database.PengestoppRepository
 import no.nav.syfo.infrastructure.kafka.StatusEndringProducer
 import no.nav.syfo.pengestopp.*
-import no.nav.syfo.testutils.TestDB
-import no.nav.syfo.testutils.UserConstants
-import no.nav.syfo.testutils.dropData
+import no.nav.syfo.testutils.*
 import no.nav.syfo.testutils.generator.genereateManglendeMedvirkningVurdering
-import no.nav.syfo.testutils.testEnvironment
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
-import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.RecordMetadata
-import org.apache.kafka.common.TopicPartition
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.time.Duration
@@ -96,10 +90,3 @@ class ManglendeMedvirkningVurderingConsumerSpek : Spek({
         }
     }
 })
-
-private fun mockRecords(records: List<ManglendeMedvirkningVurderingRecord>): ConsumerRecords<String, ManglendeMedvirkningVurderingRecord> {
-    val consumerRecords = records.mapIndexed { index, record ->
-        ConsumerRecord("topic", 0, index.toLong(), "key$index", record)
-    }
-    return ConsumerRecords(mapOf(TopicPartition("topic", 0) to consumerRecords))
-}

--- a/src/test/kotlin/no/nav/syfo/testutils/KafkaUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/testutils/KafkaUtils.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.testutils
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.common.TopicPartition
+
+fun <T> mockRecords(records: List<T>): ConsumerRecords<String, T> {
+    val consumerRecords = records.mapIndexed { index, record ->
+        ConsumerRecord("topic", 0, index.toLong(), "key$index", record)
+    }
+    return ConsumerRecords(mapOf(TopicPartition("topic", 0) to consumerRecords))
+}

--- a/src/test/kotlin/no/nav/syfo/testutils/TestDB.kt
+++ b/src/test/kotlin/no/nav/syfo/testutils/TestDB.kt
@@ -31,6 +31,8 @@ class TestDB : DatabaseInterface {
     }
 }
 
+fun DatabaseInterface.dropData() = this.connection.use { it.dropData() }
+
 fun Connection.dropData() {
     val queryList = listOf(
         """

--- a/src/test/kotlin/no/nav/syfo/testutils/generator/KafkaRecordsGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutils/generator/KafkaRecordsGenerator.kt
@@ -1,11 +1,14 @@
 package no.nav.syfo.testutils.generator
 
+import no.nav.syfo.infrastructure.kafka.arbeidsuforhet.ArbeidsuforhetVurderingRecord
 import no.nav.syfo.infrastructure.kafka.manglendemedvirkning.ManglendeMedvirkningVurderingRecord
 import no.nav.syfo.infrastructure.kafka.manglendemedvirkning.VurderingType
 import no.nav.syfo.infrastructure.kafka.manglendemedvirkning.VurderingTypeDTO
 import no.nav.syfo.testutils.UserConstants
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
+import no.nav.syfo.infrastructure.kafka.arbeidsuforhet.VurderingType as ArbeidsuforhetVurderingType
 
 fun genereateManglendeMedvirkningVurdering(type: VurderingType): ManglendeMedvirkningVurderingRecord =
     ManglendeMedvirkningVurderingRecord(
@@ -14,4 +17,17 @@ fun genereateManglendeMedvirkningVurdering(type: VurderingType): ManglendeMedvir
         veilederident = "Z999999",
         createdAt = OffsetDateTime.now(),
         vurderingType = VurderingTypeDTO(type)
+    )
+
+fun generateArbeidsuforhetVurdering(type: ArbeidsuforhetVurderingType) =
+    ArbeidsuforhetVurderingRecord(
+        uuid = UUID.randomUUID(),
+        createdAt = OffsetDateTime.now(),
+        personident = UserConstants.SYKMELDT_PERSONIDENT.value,
+        veilederident = "Z999999",
+        type = type,
+        arsak = null,
+        begrunnelse = "tekst",
+        gjelderFom = LocalDate.now(),
+        isFinal = true,
     )


### PR DESCRIPTION
Lignende funksjonalitet som vi gjorde for 8-8 mangelende medvirkning. Vi skrev også tester vha JUnit i stedet for Spek, forstod det slik at vi ville over til dette da vi begynte på `isoppfolgingsplan`-appen.

Co-authored by: @ingring 