### PR TITLE
IS-3131: Consume aktivitetskravvurderinger and send stopp to Speil

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -23,6 +23,7 @@ import no.nav.syfo.infrastructure.kafka.identhendelse.IdenthendelseConsumerServi
 import no.nav.syfo.infrastructure.kafka.identhendelse.launchKafkaTaskIdenthendelse
 import no.nav.syfo.infrastructure.database.PengestoppRepository
 import no.nav.syfo.infrastructure.kafka.StatusEndringProducer
+import no.nav.syfo.infrastructure.kafka.aktivitetskrav.launchKafkaTaskAktivitetskrav
 import no.nav.syfo.infrastructure.kafka.arbeidsuforhet.launchKafkaTaskArbeidsuforhet
 import no.nav.syfo.infrastructure.kafka.createPersonFlagget84AivenConsumer
 import no.nav.syfo.infrastructure.kafka.launchKafkaTask
@@ -134,6 +135,11 @@ fun main() {
                     pengestoppService = pengestoppService,
                 )
                 launchKafkaTaskArbeidsuforhet(
+                    applicationState = applicationState,
+                    environment = environment,
+                    pengestoppService = pengestoppService,
+                )
+                launchKafkaTaskAktivitetskrav(
                     applicationState = applicationState,
                     environment = environment,
                     pengestoppService = pengestoppService,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/aktivitetskrav/AktivitetskravVurderingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/aktivitetskrav/AktivitetskravVurderingConsumer.kt
@@ -1,0 +1,47 @@
+package no.nav.syfo.infrastructure.kafka.aktivitetskrav
+
+import no.nav.syfo.application.PengestoppService
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.pengestopp.*
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.*
+
+class AktivitetskravVurderingConsumer(
+    private val pengestoppService: PengestoppService,
+    private val kafkaConsumer: KafkaConsumer<String, AktivitetskravVurderingRecord>,
+) {
+    fun pollAndProcessRecords() {
+        val records = kafkaConsumer.poll(Duration.ofSeconds(POLL_DURATION_SECONDS))
+        if (records.count() > 0) {
+            val stansVurderinger = records.mapNotNull { it.value() }.filter { it.status == AktivitetskravStatus.INNSTILLING_OM_STANS.name }
+            if (stansVurderinger.isNotEmpty()) {
+                val statusEndringer = stansVurderinger.map { vurdering ->
+                    StatusEndring(
+                        uuid = UUID.randomUUID().toString(),
+                        veilederIdent = vurdering.updatedBy?.let { VeilederIdent(it) }
+                            ?: throw IllegalStateException("Stans-vurderingen mangler veilederIdent og kan ikke lagres"),
+                        sykmeldtFnr = PersonIdent(vurdering.personIdent),
+                        status = Status.STOPP_AUTOMATIKK,
+                        arsakList = listOf(Arsak(SykepengestoppArsak.AKTIVITETSKRAV)),
+                        virksomhetNr = null,
+                        opprettet = OffsetDateTime.now(ZoneOffset.UTC),
+                        enhetNr = null,
+                    )
+                }
+
+                pengestoppService.createStatusendringer(statusEndringer)
+                log.info("AktivitetskravVurderingConsumer created ${statusEndringer.size} statusendringer")
+            }
+        }
+        kafkaConsumer.commitSync()
+    }
+
+    companion object {
+        private const val POLL_DURATION_SECONDS = 10L
+        private val log = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/aktivitetskrav/AktivitetskravVurderingRecord.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/aktivitetskrav/AktivitetskravVurderingRecord.kt
@@ -1,0 +1,35 @@
+package no.nav.syfo.infrastructure.kafka.aktivitetskrav
+
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.*
+
+data class AktivitetskravVurderingRecord(
+    val uuid: UUID,
+    val personIdent: String,
+    val createdAt: OffsetDateTime,
+    val status: String,
+    val isFinal: Boolean,
+    val beskrivelse: String?,
+    val arsaker: List<String>,
+    val stoppunktAt: LocalDate,
+    val updatedBy: String?,
+    val sisteVurderingUuid: UUID?,
+    val sistVurdert: OffsetDateTime?,
+    val frist: LocalDate?,
+    val previousAktivitetskravUuid: UUID?,
+)
+
+enum class AktivitetskravStatus(val isFinal: Boolean) {
+    NY(false),
+    NY_VURDERING(false),
+    AVVENT(false),
+    UNNTAK(true),
+    OPPFYLT(true),
+    AUTOMATISK_OPPFYLT(true),
+    FORHANDSVARSEL(false),
+    INNSTILLING_OM_STANS(true),
+    IKKE_OPPFYLT(true),
+    IKKE_AKTUELL(true),
+    LUKKET(true),
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/aktivitetskrav/KafkaAktivitetskravTask.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/aktivitetskrav/KafkaAktivitetskravTask.kt
@@ -1,0 +1,58 @@
+package no.nav.syfo.infrastructure.kafka.aktivitetskrav
+
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.Environment
+import no.nav.syfo.application.PengestoppService
+import no.nav.syfo.application.launchBackgroundTask
+import no.nav.syfo.infrastructure.kafka.KafkaEnvironment
+import no.nav.syfo.infrastructure.kafka.commonKafkaAivenConsumerConfig
+import no.nav.syfo.objectMapper
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.Deserializer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.*
+
+const val TOPIC = "teamsykefravr.aktivitetskrav-vurdering"
+val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
+
+fun launchKafkaTaskAktivitetskrav(
+    applicationState: ApplicationState,
+    environment: Environment,
+    pengestoppService: PengestoppService,
+) {
+    launchBackgroundTask(
+        applicationState = applicationState
+    ) {
+        log.info("Setting up kafka consumer for ${AktivitetskravVurderingRecord::class.java.simpleName}")
+
+        val kafkaConsumer = KafkaConsumer<String, AktivitetskravVurderingRecord>(
+            kafkaConsumerConfig(kafkaEnvironment = environment.kafka)
+        )
+        val aktivitetskravVurderingConsumer = AktivitetskravVurderingConsumer(
+            pengestoppService = pengestoppService,
+            kafkaConsumer = kafkaConsumer,
+        )
+
+        while (applicationState.ready) {
+            if (kafkaConsumer.subscription().isEmpty()) {
+                kafkaConsumer.subscribe(listOf(TOPIC))
+            }
+            aktivitetskravVurderingConsumer.pollAndProcessRecords()
+        }
+    }
+}
+
+private fun kafkaConsumerConfig(
+    kafkaEnvironment: KafkaEnvironment,
+): Properties = Properties().apply {
+    putAll(commonKafkaAivenConsumerConfig(kafkaEnvironment))
+    this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = AktivitetskravVurderingRecordDeserializer::class.java.canonicalName
+    this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "latest"
+}
+
+class AktivitetskravVurderingRecordDeserializer : Deserializer<AktivitetskravVurderingRecord> {
+    override fun deserialize(topic: String, data: ByteArray): AktivitetskravVurderingRecord =
+        objectMapper.readValue(data, AktivitetskravVurderingRecord::class.java)
+}

--- a/src/test/kotlin/no/nav/syfo/infrastructure/kafka/aktivitetskrav/AktivitetskravVurderingConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/kafka/aktivitetskrav/AktivitetskravVurderingConsumerTest.kt
@@ -1,0 +1,119 @@
+package no.nav.syfo.infrastructure.kafka.aktivitetskrav
+
+import io.mockk.*
+import no.nav.syfo.application.PengestoppService
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.infrastructure.database.PengestoppRepository
+import no.nav.syfo.infrastructure.kafka.StatusEndringProducer
+import no.nav.syfo.pengestopp.Status
+import no.nav.syfo.pengestopp.StatusEndring
+import no.nav.syfo.pengestopp.SykepengestoppArsak
+import no.nav.syfo.testutils.TestDB
+import no.nav.syfo.testutils.dropData
+import no.nav.syfo.testutils.generator.generateAktivitetskravVurdering
+import no.nav.syfo.testutils.mockRecords
+import no.nav.syfo.testutils.testEnvironment
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
+import java.util.concurrent.Future
+import kotlin.test.assertEquals
+
+class AktivitetskravVurderingConsumerTest {
+
+    val database = TestDB()
+    val env = testEnvironment()
+
+    val kafkaProducer = mockk<KafkaProducer<String, StatusEndring>>()
+    val kafkaConsumer = mockk<KafkaConsumer<String, AktivitetskravVurderingRecord>>()
+
+    val repository = PengestoppRepository(database = database)
+    val statusEndringProducer = StatusEndringProducer(
+        environment = env,
+        kafkaProducer = kafkaProducer,
+    )
+    val pengestoppService = PengestoppService(
+        pengestoppRepository = repository,
+        statusEndringProducer = statusEndringProducer,
+    )
+
+    val aktivitetskravVurderingConsumer = AktivitetskravVurderingConsumer(
+        pengestoppService = pengestoppService,
+        kafkaConsumer = kafkaConsumer,
+    )
+
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+        every { kafkaConsumer.commitSync() } returns Unit
+        every { kafkaProducer.send(any()) } returns mockk<Future<RecordMetadata>>(relaxed = true)
+        database.dropData()
+    }
+
+    @Test
+    fun `creates statusendring and publish to kafka when aktivitetskravvurdering is INNSTILLING_OM_STANS`() {
+        val vurdering = generateAktivitetskravVurdering(AktivitetskravStatus.INNSTILLING_OM_STANS)
+        val records = mockRecords(listOf(vurdering))
+        every { kafkaConsumer.poll(any<Duration>()) } returns records
+
+        aktivitetskravVurderingConsumer.pollAndProcessRecords()
+
+        val statusEndring = repository.getStatusEndringer(personIdent = PersonIdent(vurdering.personIdent)).firstOrNull()
+        assertEquals(statusEndring?.arsakList?.get(0)?.type, SykepengestoppArsak.AKTIVITETSKRAV)
+        assertEquals(statusEndring?.sykmeldtFnr?.value, vurdering.personIdent)
+        assertEquals(statusEndring?.status, Status.STOPP_AUTOMATIKK)
+        assertEquals(statusEndring?.veilederIdent?.value, vurdering.updatedBy)
+
+        verify(exactly = 1) { kafkaProducer.send(any()) }
+        verify(exactly = 1) { kafkaConsumer.commitSync() }
+    }
+
+    @Test
+    fun `creates several statusendinger when multiple aktivitetskravvurderinger are INNSTILLING_OM_STANS`() {
+        val vurdering1 = generateAktivitetskravVurdering(AktivitetskravStatus.INNSTILLING_OM_STANS)
+        val vurdering2 = generateAktivitetskravVurdering(AktivitetskravStatus.INNSTILLING_OM_STANS)
+        val records = mockRecords(listOf(vurdering1, vurdering2))
+        every { kafkaConsumer.poll(any<Duration>()) } returns records
+
+        aktivitetskravVurderingConsumer.pollAndProcessRecords()
+
+        val statusEndringer = repository.getStatusEndringer(personIdent = PersonIdent(vurdering1.personIdent))
+        assertEquals(statusEndringer.size, 2)
+
+        verify(exactly = 2) { kafkaProducer.send(any()) }
+        verify(exactly = 1) { kafkaConsumer.commitSync() }
+    }
+
+    @Test
+    fun `does not create statusendring nor publish to kafka when aktivitetskravvurdering is not INNSTILLING_OM_STANS`() {
+        val vurdering = generateAktivitetskravVurdering(AktivitetskravStatus.UNNTAK)
+        val records = mockRecords(listOf(vurdering))
+        every { kafkaConsumer.poll(any<Duration>()) } returns records
+
+        aktivitetskravVurderingConsumer.pollAndProcessRecords()
+
+        val statusEndring = repository.getStatusEndringer(personIdent = PersonIdent(vurdering.personIdent)).firstOrNull()
+        assertEquals(statusEndring, null)
+
+        verify(exactly = 0) { kafkaProducer.send(any()) }
+        verify(exactly = 1) { kafkaConsumer.commitSync() }
+    }
+
+    @Test
+    fun `throws error when aktivitetskravvurdering is missing veilederIdent`() {
+        val vurdering = generateAktivitetskravVurdering(AktivitetskravStatus.INNSTILLING_OM_STANS).copy(updatedBy = null)
+        val records = mockRecords(listOf(vurdering))
+        every { kafkaConsumer.poll(any<Duration>()) } returns records
+
+        assertThrows<IllegalStateException> {
+            aktivitetskravVurderingConsumer.pollAndProcessRecords()
+        }
+
+        verify(exactly = 0) { kafkaProducer.send(any()) }
+        verify(exactly = 0) { kafkaConsumer.commitSync() }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/testutils/generator/KafkaRecordsGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutils/generator/KafkaRecordsGenerator.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.testutils.generator
 
+import no.nav.syfo.infrastructure.kafka.aktivitetskrav.AktivitetskravStatus
+import no.nav.syfo.infrastructure.kafka.aktivitetskrav.AktivitetskravVurderingRecord
 import no.nav.syfo.infrastructure.kafka.arbeidsuforhet.ArbeidsuforhetVurderingRecord
 import no.nav.syfo.infrastructure.kafka.manglendemedvirkning.ManglendeMedvirkningVurderingRecord
 import no.nav.syfo.infrastructure.kafka.manglendemedvirkning.VurderingType
@@ -30,4 +32,21 @@ fun generateArbeidsuforhetVurdering(type: ArbeidsuforhetVurderingType) =
         begrunnelse = "tekst",
         gjelderFom = LocalDate.now(),
         isFinal = true,
+    )
+
+fun generateAktivitetskravVurdering(status: AktivitetskravStatus) =
+    AktivitetskravVurderingRecord(
+        uuid = UUID.randomUUID(),
+        personIdent = UserConstants.SYKMELDT_PERSONIDENT.value,
+        createdAt = OffsetDateTime.now(),
+        status = status.name,
+        isFinal = false,
+        beskrivelse = "beskrivelse",
+        arsaker = listOf("arsak"),
+        stoppunktAt = LocalDate.now(),
+        updatedBy = "Z999999",
+        sisteVurderingUuid = UUID.randomUUID(),
+        sistVurdert = OffsetDateTime.now(),
+        frist = LocalDate.now(),
+        previousAktivitetskravUuid = UUID.randomUUID(),
     )


### PR DESCRIPTION
Innfører samme mønster som for 8-8 og 8-4.
Tilgang gitt i https://github.com/navikt/isaktivitetskrav/pull/294

Co-authored by: @ingring 